### PR TITLE
feat: 회원정보 조회

### DIFF
--- a/gogildong/src/Mypage/api/getUserInfo.ts
+++ b/gogildong/src/Mypage/api/getUserInfo.ts
@@ -1,0 +1,8 @@
+import axiosInstance from "@/common/api/axiosInstance";
+import { useUserStore } from "../stores/useUserStore";
+
+export const getUserInfo = async () => {
+  const { data } = await axiosInstance.get("/users/me");
+  useUserStore.getState().setUser(data);
+  return data;
+};

--- a/gogildong/src/Mypage/pages/Mypage.tsx
+++ b/gogildong/src/Mypage/pages/Mypage.tsx
@@ -7,18 +7,6 @@ import { calculateJoinedDays } from "../utils/calculateJoinedDays";
 import { useUserStore } from "../stores/useUserStore";
 import { getUserInfo } from "../api/getUserInfo";
 
-type UserInfo = {
-  userId: number;
-  loginId: string;
-  password: string;
-  username: string;
-  role: "INTERNAL" | "EXTERNAL";
-  email: string;
-  phone: string;
-  createdAt: string; // "2025-01-01"
-  profileImageUrl: string | null;
-};
-
 export default function Mypage() {
   const [active, setActive] = React.useState<NavKey>("mypage");
 

--- a/gogildong/src/Mypage/pages/Mypage.tsx
+++ b/gogildong/src/Mypage/pages/Mypage.tsx
@@ -1,9 +1,11 @@
 import Header from "@/common/components/Header";
 import NavBar, { type NavKey } from "@/common/components/NavBar";
-import React from "react";
+import React, { useEffect } from "react";
 import ProfileSection from "../components/ProfileSection";
 import MenuList from "../components/MenuList";
 import { calculateJoinedDays } from "../utils/calculateJoinedDays";
+import { useUserStore } from "../stores/useUserStore";
+import { getUserInfo } from "../api/getUserInfo";
 
 type UserInfo = {
   userId: number;
@@ -13,30 +15,31 @@ type UserInfo = {
   role: "INTERNAL" | "EXTERNAL";
   email: string;
   phone: string;
-  createAt: string; // "2025-01-01"
+  createdAt: string; // "2025-01-01"
   profileImageUrl: string | null;
 };
 
 export default function Mypage() {
   const [active, setActive] = React.useState<NavKey>("mypage");
 
-  // TODO: 실제 API 연동으로 대체
-  const user: UserInfo = {
-    userId: 1,
-    loginId: "testId",
-    password: "testpw",
-    username: "홍길동",
-    role: "INTERNAL",
-    email: "test@gamil.com",
-    phone: "010-1234-5678",
-    createAt: "2025-12-01",
-    profileImageUrl: ""
-  };
+  const user = useUserStore((state) => state.user);
 
-  const joinedDays = React.useMemo(
-    () => calculateJoinedDays(user.createAt),
-    [user.createAt]
-  );
+  useEffect(() => {
+    getUserInfo();
+  }, []);
+
+  const joinedDays = React.useMemo(() => {
+    if (!user) return 0;
+    return calculateJoinedDays(user.createdAt);
+  }, [user?.createdAt]);
+
+  if (!user) {
+    return (
+      <>
+        <div>로딩 중...</div>
+      </>
+    );
+  }
 
   const handleLogout = () => {
     // 로그아웃 로직

--- a/gogildong/src/Mypage/stores/useUserStore.ts
+++ b/gogildong/src/Mypage/stores/useUserStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export interface UserInfo {
+  userId: number;
+  loginId: string;
+  username: string;
+  role: string;
+  email: string;
+  phone: string;
+  schoolCode: string;
+  schoolName: string;
+  createdAt: string;
+}
+
+interface UserState {
+  user: UserInfo | null;
+  setUser: (user: UserInfo) => void;
+  clearUser: () => void;
+}
+
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null })
+    }),
+    { name: "user-storage" }
+  )
+);

--- a/gogildong/src/Mypage/stores/useUserStore.ts
+++ b/gogildong/src/Mypage/stores/useUserStore.ts
@@ -11,6 +11,7 @@ export interface UserInfo {
   schoolCode: string;
   schoolName: string;
   createdAt: string;
+  profileImageUrl: string;
 }
 
 interface UserState {


### PR DESCRIPTION
## 🔘Part
- [X] FE

  <br/>

## 🔎 작업 내용

- `/users/me`로 유저 정보를 받고 이를 useUserStore에 저장해두었습니다.
- 저장된 정보를 통해, 마이페이지 목데이터 대신 받아온 정보로 변경했습니다.

  <br/>

## 이미지 첨부
<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/633ea6b3-2ff0-4f70-8053-5cc33bb53bbe" />



<br/>

## 🔧 앞으로의 과제

- 로그아웃 api 연동
#60 