### PR TITLE
feat: 로그아웃 api 연동

### DIFF
--- a/gogildong/src/Mypage/api/logoutUser.ts
+++ b/gogildong/src/Mypage/api/logoutUser.ts
@@ -1,0 +1,5 @@
+import axiosInstance from "@/common/api/axiosInstance"
+
+export const logout = async () => {
+    await axiosInstance.post("/auth/logout");
+}

--- a/gogildong/src/Mypage/pages/Mypage.tsx
+++ b/gogildong/src/Mypage/pages/Mypage.tsx
@@ -6,11 +6,16 @@ import MenuList from "../components/MenuList";
 import { calculateJoinedDays } from "../utils/calculateJoinedDays";
 import { useUserStore } from "../stores/useUserStore";
 import { getUserInfo } from "../api/getUserInfo";
+import { useAuthStore } from "./../../Login/stores/useAuthStore";
+import { useNavigate } from "react-router-dom";
 
 export default function Mypage() {
+  const navigate = useNavigate();
   const [active, setActive] = React.useState<NavKey>("mypage");
 
   const user = useUserStore((state) => state.user);
+  const logoutUser = useUserStore((state) => state.logout);
+  const clearTokens = useAuthStore((state) => state.clearTokens);
 
   useEffect(() => {
     getUserInfo();
@@ -30,7 +35,13 @@ export default function Mypage() {
   }
 
   const handleLogout = () => {
-    // 로그아웃 로직
+    logoutUser();
+    clearTokens();
+
+    localStorage.removeItem("user-storage");
+    localStorage.removeItem("auth-storage");
+
+    navigate("/login");
   };
 
   return (

--- a/gogildong/src/Mypage/stores/useUserStore.ts
+++ b/gogildong/src/Mypage/stores/useUserStore.ts
@@ -17,7 +17,7 @@ export interface UserInfo {
 interface UserState {
   user: UserInfo | null;
   setUser: (user: UserInfo) => void;
-  clearUser: () => void;
+  logout: () => void;
 }
 
 export const useUserStore = create<UserState>()(
@@ -25,7 +25,7 @@ export const useUserStore = create<UserState>()(
     (set) => ({
       user: null,
       setUser: (user) => set({ user }),
-      clearUser: () => set({ user: null })
+      logout: () => set({ user: null })
     }),
     { name: "user-storage" }
   )


### PR DESCRIPTION
## 🔘Part
- [X] FE

  <br/>

## 🔎 작업 내용
- 로그아웃 api를 연동했습니다.

## ❓작업 도중 어려웠던 점
- 로그아웃 기능을 구현하는 과정에서 **React Hook 규칙 위반으로 인한 런타임 에러**가 발생했습니다.

### 에러 메시지:
```
Rendered more hooks than during the previous render.
```

문제의 원인이 된 코드는 다음과 같습니다:
```
const user = useUserStore((state) => state.user);

if (!user) {
  return <div>로딩 중...</div>;
}

const logoutUser = useUserStore((state) => state.logout);
const clearTokens = useAuthStore((state) => state.clearTokens);
```

- 이 경우, user가 null일 때 return이 먼저 실행되어 아래의 두 hook(logoutUser, clearTokens)이 호출되지 않는 렌더가 발생했습니다.
- 반대로, user가 존재하는 렌더에서는 해당 hook들이 호출되기 때문에 렌더마다 hook 호출 개수가 달라져 React Hook 규칙이 깨졌습니다.
- React는 **“모든 렌더에서 hook이 동일한 순서와 개수로 호출되어야 한다”**는 규칙을 가지고 있기 때문에 위와 같은 오류가 발생했습니다.

### 🛠 해결 방법
- 조건문 이전에 hook을 모두 배치하여, 항상 동일한 순서로 실행되도록 수정했습니다:
```
const user = useUserStore((state) => state.user);
const logoutUser = useUserStore((state) => state.logout);
const clearTokens = useAuthStore((state) => state.clearTokens);

if (!user) {
  return <div>로딩 중...</div>;
}
```
이렇게 함으로써 렌더 간에 hook 호출 순서가 달라지는 문제를 해결할 수 있었습니다.

## 이미지 첨부
![20251202-0930-11 3569760](https://github.com/user-attachments/assets/eabd63ac-f690-4235-9e9e-a361f410763c)
